### PR TITLE
Removed Extra Quotation Mark from Distro

### DIFF
--- a/fm6000.pl
+++ b/fm6000.pl
@@ -31,6 +31,7 @@ sub get_os {
     for($os){
         s/"//;
         s/ .*//;
+        s/"//;
         chomp;
     }
     return $os;


### PR DESCRIPTION
Just added a line that will remove the extra quotation that appeared after the distro name. 