### PR TITLE
fix: issue with headless option not preventing user input prompt

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,11 +47,11 @@ if [ -f "fm6000" ] && [ -s "fm6000" ]; then
             sudo=
         fi
         printf '%b' "${YELLOW}"
-        [ -n "${ans+x}" ] && read -p "Move the script to $install_path [$require_text]? (y/N) " ans
+        [ -z "$ans" ] && read -p "Move the script to $install_path [$require_text]? (y/N) " ans
     else
         install_path=/usr/local/bin
         printf '%b' "${YELLOW}"
-        [ -n "${ans+x}" ] && read -p "Move the script to $install_path [$require_text]? (y/N)  " ans
+        [ -z "$ans" ] && read -p "Move the script to $install_path [$require_text]? (y/N)  " ans
     fi
 
     if [ "${ans}" = "y" ] || [ "${ans}" = "-y" ]; then


### PR DESCRIPTION
Oops, it seems like I made a mistake with the last implementation. This one works as expected. The last one didn't prevent the prompt from showing even when `-y` or `y` were specified beforehand