### PR TITLE
Install Script v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,18 @@ download it make it executable and put somewhere in your $PATH
 ```sh
 sh -c "$(curl https://raw.githubusercontent.com/anhsirk0/fetch-master-6000/master/install.sh)"
 ```
+### install script help page
+```sh
+sh -c "$(curl https://raw.githubusercontent.com/anhsirk0/fetch-master-6000/master/install.sh)" -- -h
+```
 ### install script options
-- to define install location set "install_path" variable(this variable defaults to $HOME/.local/bin)
+- use --install-path option or set "install_path" variable(this variable defaults to $HOME/.local/bin, if it does not exist /usr/local/bin is used)
 - to define whether to use root or not set "root" variable(its value must be 1 or 0)(this variable defaults to 0 since $HOME/.local/bin is a user directory)
 ### example
+```sh
+sh -c "$(curl https://raw.githubusercontent.com/anhsirk0/fetch-master-6000/master/install.sh)" -- --install-path=/usr/bin --root
+```
+**or**
 ```sh
 install_path=/usr/bin root=1 sh -c "$(curl https://raw.githubusercontent.com/anhsirk0/fetch-master-6000/master/install.sh)"
 ```
@@ -88,34 +96,34 @@ fm6000 -say "Hello world!"
 ![geometry.png](https://github.com/anhsirk0/fetch-master-6000/blob/master/screenshots/geometry.png)
 
 ## Available Options
-**-c** or **--color=STR** Base color  
-**-w** or **--wally** Display Wally  
-**-dog** or **--dogbert** Display Dogbert  
-**-al** or **--alice** Display Alice  
-**-phb** or **--phb** Display Pointy haired Boss  
-**-as** or **--asok** Display Asok  
-**-nd** or **--not_de** To use 'WM' instead of 'DE'  
-**-o** or **--os=STR** OS name  
-**-k** or **--kernel=STR** Kernel version  
-**-d** or **--de=STR** Desktop environment name  
-**-sh** or **--shell=STR** Shell name  
-**-u** or **--uptime=STR** Uptime  
-**-p** or **--package=INT** Number of packages  
-**-v** or **--vnstat=STR** Use vnstat instead of kernel  
-**-f** or **--file** Display art from file  
-**-r** or **--random** Display Random Art  
-**-rd** or **--random-dir=STR** Directory for random ascii art  
-**-s** or **--say=STR** Say provided text instead of info  
-**-sf** or **--say-file=STR** Say text from a file instead of info  
-**-m** or **--margin=INT** Spaces on the left side of info  
-**-g** or **--gap=INT** Spaces between info and info_value  
-**-l** or **--length=INT** Length of the board ( > 14)  
-**-h** or **--help** Print this help message  
+**-c** or **--color=STR** Base color
+**-w** or **--wally** Display Wally
+**-dog** or **--dogbert** Display Dogbert
+**-al** or **--alice** Display Alice
+**-phb** or **--phb** Display Pointy haired Boss
+**-as** or **--asok** Display Asok
+**-nd** or **--not_de** To use 'WM' instead of 'DE'
+**-o** or **--os=STR** OS name
+**-k** or **--kernel=STR** Kernel version
+**-d** or **--de=STR** Desktop environment name
+**-sh** or **--shell=STR** Shell name
+**-u** or **--uptime=STR** Uptime
+**-p** or **--package=INT** Number of packages
+**-v** or **--vnstat=STR** Use vnstat instead of kernel
+**-f** or **--file** Display art from file
+**-r** or **--random** Display Random Art
+**-rd** or **--random-dir=STR** Directory for random ascii art
+**-s** or **--say=STR** Say provided text instead of info
+**-sf** or **--say-file=STR** Say text from a file instead of info
+**-m** or **--margin=INT** Spaces on the left side of info
+**-g** or **--gap=INT** Spaces between info and info_value
+**-l** or **--length=INT** Length of the board ( > 14)
+**-h** or **--help** Print this help message
 
 ## Available colors
-black  red  green  yellow  blue  magenta  cyan  
-bright_black  bright_red  bright_green  bright_yellow  
-bright_blue   bright_magenta  bright_cyan random  
+black  red  green  yellow  blue  magenta  cyan
+bright_black  bright_red  bright_green  bright_yellow
+bright_blue   bright_magenta  bright_cyan random
 
 ## Randomization
 For random color:
@@ -147,7 +155,7 @@ fm6000 -rd "directory_name"
 
 ## Troubleshooting
 If your distro is not {arch, debian, fedora, freeBSD, gentoo, venom, solus} based fetch-master-6000 wont be able to detect number of packages
-In that case you have to specify number of packages yourself  
+In that case you have to specify number of packages yourself
 For example:
 On Solus (eopkg)
 *Solus is already supported*

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ sh -c "$(curl https://raw.githubusercontent.com/anhsirk0/fetch-master-6000/maste
 ```
 ### install script options
 - use --install-path option or set "install_path" variable(this variable defaults to $HOME/.local/bin, if it does not exist /usr/local/bin is used)
-- to define whether to use root or not set "root" variable(its value must be 1 or 0)(this variable defaults to 0 since $HOME/.local/bin is a user directory)
+- use --root(-r), --noroot(-nr) or set "root" variable(this is automatically detected via stat if "root" var is not set and options are not used)
+- use --dry-run(-dr) to dry run fm6000
+-
 ### example
 ```sh
 sh -c "$(curl https://raw.githubusercontent.com/anhsirk0/fetch-master-6000/master/install.sh)" -- --install-path=/usr/bin --root

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ for opt in $@ ; do
 		;;
 		--install*path=*) install_path="${opt#*=}"
 		;;
-		--dry-run|-dr) dryrun=1
+		--dry*run|-dr) dryrun=1
 		;;
     *|-h)
 		[ -x "./install.sh" ] && prog="./install.sh" || prog="sh -c \"\$(curl https://raw.githubusercontent.com/anhsirk0/fetch-master-6000/master/install.sh)\""
@@ -98,7 +98,7 @@ if [ -f "fm6000.pl" ]; then
     cp fm6000.pl fm6000
 else
     url="https://raw.githubusercontent.com/anhsirk0/fetch-master-6000/master/fm6000.pl"
-    if [ "$(command -v curl)" ]; then
+    if check_dep "curl"; then
         out "${BLUE}Downloading the script${NC}"
         curl $url -o fm6000
     else
@@ -125,7 +125,7 @@ if [ -f "fm6000" ] && [ -s "fm6000" ]; then
     printf '%b' "${YELLOW}"
     notset "$dryrun" && read -p "Move the script to $install_path [$require_text]? (y/N) " ans
 
-		if notset "$dryrun"; then
+		if notset "$dryrun" && [ "${ans}" = "y" ] || [ "${ans}" = "Y" ]; then
         out "${BLUE}Moving fm6000 to $install_path${NC}"
         printf '%b' "${CYAN}"
         $sudo mv -v fm6000 $install_path || {

--- a/install.sh
+++ b/install.sh
@@ -24,11 +24,11 @@ notset() {
 }
 
 check_dep() {
-	if [ "$(command -v $1)" ]; then return 0; else return 1; fi
+	if [ "$(command -v "$1")" ]; then return 0; else return 1; fi
 }
 
 ## get options
-for opt in $@; do
+for opt in "$@"; do
 	case $opt in
 	--nocolors | -nc)
 		# unset colors
@@ -51,7 +51,7 @@ for opt in $@; do
 	--headless | -y)
 		headless=1
 		;;
-	* | -h)
+	-h | *)
 		[ -x "./install.sh" ] && prog="./install.sh" || prog="sh -c \"\$(curl https://raw.githubusercontent.com/anhsirk0/fetch-master-6000/master/install.sh)\""
 		out \
 			"${RED}------${NC} ${CYAN}Fetch-Master-6000 install script${NC} ${RED}------${NC}
@@ -71,7 +71,7 @@ done
 # make script compatible with env variables
 
 ## set install_path
-notset $install_path && {
+notset "$install_path" && {
 	if [ -x "$HOME/.local/bin" ]; then
 		install_path=$HOME/.local/bin
 	elif [ -x "/usr/local/bin" ]; then
@@ -80,7 +80,7 @@ notset $install_path && {
 }
 
 ## check if $install_path requires root group
-notset $install_path || {
+notset "$install_path" || {
 	[ ! -x "$install_path" ] && {
 		out "${RED}$install_path does not exist${NC}"
 		return 1
@@ -96,7 +96,7 @@ notset $install_path || {
 [ "$root" = "0" ] && root=
 
 ## root text and else
-if notset $root; then
+if notset "$root"; then
 	require_text="root not required"
 	sudo=
 else
@@ -123,7 +123,7 @@ fi
 if ! notset "$root"; then
 	## if user is root do not set sudo
 	if [ "$(id -u)" -eq "0" ]; then
-		continue
+		sudo=
 	## check if doas is available
 	elif [ "$(command -v doas)" ]; then
 		sudo=doas
@@ -136,13 +136,14 @@ fi
 if [ -f "fm6000" ] && [ -s "fm6000" ]; then
 	chmod +x fm6000 && out "${BLUE}Making the script executable : ${GREEN}done"
 
+	# shellcheck disable=SC2086
 	if check_dep "find" && [ "$(find /usr/bin /usr/local/bin $HOME/.local/bin -type f -iname 'fm6000')" ]; then
 		out "${RED}it seems fm6000 is already installed but continuing anyway${NC}"
 	fi
 
-	notset "$dryrun" && {
-		printf '%b' "${YELLOW}"
-		notset "$headless" && read -p "Move the script to $install_path [$require_text]? (y/N) " ans
+	notset "$dryrun" && notset "$headless" && {
+		printf '%b' "${YELLOW}Move the script to $install_path [${RED}$require_text${YELLOW}]? (y/N) "
+		read -r ans
 	}
 
 	case $ans in

--- a/install.sh
+++ b/install.sh
@@ -38,18 +38,21 @@ for opt in $@ ; do
 		;;
 		--root|-r) root=1
 		;;
-		--install_path=*) install_path="${opt#*=}"
+		--no*root|-nr) root=0
+		;;
+		--install*path=*) install_path="${opt#*=}"
 		;;
 		--dry-run|-dr) dryrun=1
 		;;
-	*|-h)
+    *|-h)
 		[ -x "./install.sh" ] && prog="./install.sh" || prog="sh -c \"\$(curl https://raw.githubusercontent.com/anhsirk0/fetch-master-6000/master/install.sh)\""
 		out \
 "${RED}------${NC} ${CYAN}Fetch-Master-6000 install script${NC} ${RED}------${NC}
 ${YELLOW}Usage:${NC} $prog ${BLUE}<options>${NC}
 
  ${RED}--nocolors${NC},${RED} -nc    ${GREEN}Do not print colored text${NC}
- ${RED}--root${NC},${RED}     -r     ${GREEN}Force root${NC}
+ ${RED}--root${NC},${RED}     -r     ${GREEN}Use root privileges(it is automatically detected but still can be used)${NC}
+ ${RED}--noroot${NC},${RED}   -nr    ${GREEN}Do not use root privileges(it is automatically detected but still can be used)${NC}
  ${RED}--dry-run${NC},${RED}  -dr    ${GREEN}Dry run fm6000${NC}
 "
 		return 1
@@ -67,9 +70,13 @@ notset $install_path && {
 
 ## check if $install_path requires root group
 notset $install_path || {
+	[ ! -x "$install_path" ] && {
+    out "${RED}$install_path does not exist${NC}"
+		return 1
+	}
 	check_dep "stat" && {
 		if [ "$(stat -c "%G" $install_path)" = "root" ]; then
-			root=1
+			notset "$root" && root=1
 		fi
 	}
 }

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ out() {
 }
 
 notset() {
-	case $1 in '') return 0 ;; *) return 1; esac
+	case $1 in '') return 0 ;; *) return 1 ;; esac
 }
 
 check_dep() {
@@ -28,34 +28,43 @@ check_dep() {
 }
 
 ## get options
-for opt in $@ ; do
+for opt in $@; do
 	case $opt in
-		--nocolors|-nc)
-			# unset colors
-			for i in RED GREEN YELLOW BLUE CYAN NC; do
-				unset $i
-			done
+	--nocolors | -nc)
+		# unset colors
+		for i in RED GREEN YELLOW BLUE CYAN NC; do
+			unset $i
+		done
 		;;
-		--root|-r) root=1
+	--root | -r)
+		root=1
 		;;
-		--no*root|-nr) root=0
+	--no*root | -nr)
+		root=0
 		;;
-		--install*path=*) install_path="${opt#*=}"
+	--install*path=*)
+		install_path="${opt#*=}"
 		;;
-		--dry*run|-dr) dryrun=1
+	--dry*run | -dr)
+		dryrun=1
 		;;
-    *|-h)
+	--headless | -y)
+		headless=1
+		;;
+	* | -h)
 		[ -x "./install.sh" ] && prog="./install.sh" || prog="sh -c \"\$(curl https://raw.githubusercontent.com/anhsirk0/fetch-master-6000/master/install.sh)\""
 		out \
-"${RED}------${NC} ${CYAN}Fetch-Master-6000 install script${NC} ${RED}------${NC}
+			"${RED}------${NC} ${CYAN}Fetch-Master-6000 install script${NC} ${RED}------${NC}
 ${YELLOW}Usage:${NC} $prog ${BLUE}<options>${NC}
 
  ${RED}--nocolors${NC},${RED} -nc    ${GREEN}Do not print colored text${NC}
  ${RED}--root${NC},${RED}     -r     ${GREEN}Use root privileges(it is automatically detected but still can be used)${NC}
  ${RED}--noroot${NC},${RED}   -nr    ${GREEN}Do not use root privileges(it is automatically detected but still can be used)${NC}
  ${RED}--dry-run${NC},${RED}  -dr    ${GREEN}Dry run fm6000${NC}
+ ${RED}--headless${NC},${RED} -y     ${GREEN}install headless(without prompting)${NC}
 "
 		return 1
+		;;
 	esac
 done
 
@@ -63,15 +72,17 @@ done
 
 ## set install_path
 notset $install_path && {
-	if	[ -x "$HOME/.local/bin" ]; then install_path=$HOME/.local/bin
-	elif [ -x "/usr/local/bin" ]; then install_path=/usr/local/bin
+	if [ -x "$HOME/.local/bin" ]; then
+		install_path=$HOME/.local/bin
+	elif [ -x "/usr/local/bin" ]; then
+		install_path=/usr/local/bin
 	fi
 }
 
 ## check if $install_path requires root group
 notset $install_path || {
 	[ ! -x "$install_path" ] && {
-    out "${RED}$install_path does not exist${NC}"
+		out "${RED}$install_path does not exist${NC}"
 		return 1
 	}
 	check_dep "stat" && {
@@ -87,58 +98,76 @@ notset $install_path || {
 ## root text and else
 if notset $root; then
 	require_text="root not required"
-  sudo=
+	sudo=
 else
-  require_text="root required"
+	require_text="root required"
 fi
+
+## set headless when it is not already set
+notset "$headless" && headless=
 
 ## download fm6000 if it does not exist
 if [ -f "fm6000.pl" ]; then
-    out "${BLUE}Seems like you cloned the repository${NC}"
-    cp fm6000.pl fm6000
+	out "${BLUE}Seems like you cloned the repository${NC}"
+	cp fm6000.pl fm6000
 else
-    url="https://raw.githubusercontent.com/anhsirk0/fetch-master-6000/master/fm6000.pl"
-    if check_dep "curl"; then
-        out "${BLUE}Downloading the script${NC}"
-        curl $url -o fm6000
-    else
-        out "${RED}curl is required${NC}" && return 1
-    fi
+	url="https://raw.githubusercontent.com/anhsirk0/fetch-master-6000/master/fm6000.pl"
+	if check_dep "curl"; then
+		out "${BLUE}Downloading the script${NC}"
+		curl $url -o fm6000
+	else
+		out "${RED}curl is required${NC}" && return 1
+	fi
 fi
 
 if ! notset "$root"; then
 	## if user is root do not set sudo
 	if [ "$(id -u)" -eq "0" ]; then
-			continue
+		continue
 	## check if doas is available
 	elif [ "$(command -v doas)" ]; then
-			sudo=doas
+		sudo=doas
 	## if user is not root and doas is not found fallback to sudo
 	else
-			sudo=sudo
+		sudo=sudo
 	fi
 fi
 
 if [ -f "fm6000" ] && [ -s "fm6000" ]; then
-    chmod +x fm6000 && out "${BLUE}Making the script executable : ${GREEN}done"
+	chmod +x fm6000 && out "${BLUE}Making the script executable : ${GREEN}done"
 
-    printf '%b' "${YELLOW}"
-    notset "$dryrun" && read -p "Move the script to $install_path [$require_text]? (y/N) " ans
+	if check_dep "find" && [ "$(find /usr/bin /usr/local/bin $HOME/.local/bin -type f -iname 'fm6000')" ]; then
+		out "${RED}it seems fm6000 is already installed but continuing anyway${NC}"
+	fi
 
-		if notset "$dryrun" && [ "${ans}" = "y" ] || [ "${ans}" = "Y" ]; then
-        out "${BLUE}Moving fm6000 to $install_path${NC}"
-        printf '%b' "${CYAN}"
-        $sudo mv -v fm6000 $install_path || {
-            out "${RED}error: $sudo failed${NC}"
-            return 1
-				}
-        out "${GREEN}Fetch-master-6000 is successfully installed${NC}"
-        return 0
-    else
-        out "${YELLOW}Script not moved!${NC}"
-        ./fm6000
-        return 0
-    fi
+	notset "$dryrun" && {
+		printf '%b' "${YELLOW}"
+		notset "$headless" && read -p "Move the script to $install_path [$require_text]? (y/N) " ans
+	}
+
+	case $ans in
+	y | Y | -y | -Y)
+		ans="y"
+		;;
+	*)
+		ans="N"
+		;;
+	esac
+
+	if [ "$headless" = "1" ] || [ "$ans" = "y" ]; then
+		out "${BLUE}Moving fm6000 to $install_path${NC}"
+		printf '%b' "${CYAN}"
+		$sudo mv -v fm6000 $install_path || {
+			out "${RED}error: $sudo failed${NC}"
+			return 1
+		}
+		out "${GREEN}Fetch-master-6000 is successfully installed${NC}"
+		return 0
+	else
+		out "${YELLOW}Script not moved!${NC}"
+		./fm6000
+		return 0
+	fi
 else
-    out "${RED}Unable to download the script${NC}"
+	out "${RED}Unable to download the script${NC}"
 fi


### PR DESCRIPTION
# What is done
- Code improvents/cleanup
- New option management system `./install.sh --install-path=/usr/bin --dry-run`
- Automatic detection of $install_path directory group using stat, if group = root script will use $sudo
- Options
```
    --root,     -r
    --noroot,   -nr
    --dry-run,  -dr
    --nocolors, -nc
    --headless, -y
    --help,     -h
```

# TODO
- [x] add headless install back
- [x] format the script using shfmt